### PR TITLE
added import for analysis.dense.sensitivity

### DIFF
--- a/msmtools/analysis/dense/__init__.py
+++ b/msmtools/analysis/dense/__init__.py
@@ -26,4 +26,5 @@ from . import expectations
 from . import fingerprints
 from . import hitting_probability
 from . import mean_first_passage_time
+from . import sensitivity
 from . import pcca


### PR DESCRIPTION
`analysis.dense.__init__` had `from . import sensitivity` missing. As a result the analysis.sensitivity... commands were not callable. I don't understand why the tests in `tests.test_sensitivity` did not run into this problem though. @trendelkampschroer or @marscher  any ideas?
