### PR TITLE
[util.statistics.confidence_interval]: handling constant data

### DIFF
--- a/msmtools/util/statistics.py
+++ b/msmtools/util/statistics.py
@@ -28,13 +28,13 @@ from six.moves import range
 import numpy as np
 import math
 import itertools
+import warnings
 
 from msmtools.util import types
 
 
 def _confidence_interval_1d(data, alpha):
-    """
-    Computes the mean and alpha-confidence interval of the given sample set
+    """ Computes the mean and alpha-confidence interval of the given sample set
 
     Parameters
     ----------
@@ -48,9 +48,17 @@ def _confidence_interval_1d(data, alpha):
     (m, l, r) : m is the mean of the data, and (l, r) are the m-alpha/2
         and m+alpha/2 confidence interval boundaries.
     """
+    # CHECK INPUT
     if alpha < 0 or alpha > 1:
         raise ValueError('Not a meaningful confidence level: '+str(alpha))
+    # exception: if data are constant, return three times the constant and raise a warning
+    dmin = np.min(data)
+    dmax = np.max(data)
+    if dmin == dmax:
+        warnings.warn('confidence interval for constant data is not meaningful')
+        return dmin, dmin, dmin
 
+    # COMPUTE INTERVAL
     # compute mean
     m = np.mean(data)
     # sort data


### PR DESCRIPTION
Algorithmic fix for #66. However I am not sure what is the most meaningful behavior here. Credible intervals are defined as follows: if (l,r) is a probability p credible interval, then the probability that a sample x fulfills in l <= x <= r is p. So if our data are constant, then only 0% and 100% credible intervals exist. 

If we want to be hardcore, we should raise a ValueError when calling this function with values of p different from 0 or 1. That's not very practical though, because for multidimensional data it happens often that some dimensions are constant, and then we would like this function still to be applicable. I now chose to just return the constant value as l and r irrespective of p, but to raise a warning. It's debatable whether that is the best solution - perhaps even the warning is too annoying?

@trendelkampschroer , can you comment or merge if you are happy with this solution? If acceptable, please mirror this change in `pyemma.utils.statistics` in your recent PR.

Fixes #66 
