### PR TITLE
[estimation/MLE] Handle case of tiny elements in statdist, which led to eigenvalues > 1 in decomposition.

### DIFF
--- a/msmtools/estimation/api.py
+++ b/msmtools/estimation/api.py
@@ -959,10 +959,19 @@ def transition_matrix(C, reversible=False, mu=None, method='auto', **kwargs):
             raise NotImplementedError('nonreversible mle with fixed stationary distribution not implemented.')
 
     # convert return type
+    return_statdist = 'return_statdist' in kwargs
     if sparse_computation and not sparse_input_type:
-        return T.toarray()
+        if return_statdist:
+            raise NotImplementedError()
+            return T[0].toarray(), T[1]
+        else:
+            return T.toarray()
     elif not sparse_computation and sparse_input_type:
-        return csr_matrix(T)
+        if return_statdist:
+            raise NotImplementedError()
+            return csr_matrix(T[0]), T[1]
+        else:
+            return csr_matrix(T)
     else:
         return T
 

--- a/msmtools/estimation/sparse/_mle_trev.h
+++ b/msmtools/estimation/sparse/_mle_trev.h
@@ -16,4 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-int _mle_trev_sparse(double * const T_data, const double * const CCt_data, const int * const i_indices, const int * const j_indices, const int len_CCt, const double * const sum_C, const int dim, const double maxerr, const int maxiter);
+int _mle_trev_sparse(double * const T_data, const double * const CCt_data,
+		const int * const i_indices, const int * const j_indices,
+		const int len_CCt, const double * const sum_C, const int dim,
+		const double maxerr, const int maxiter,
+//		double * const mu,
+		double mu_eps);

--- a/msmtools/estimation/sparse/mle_trev.pyx
+++ b/msmtools/estimation/sparse/mle_trev.pyx
@@ -8,14 +8,24 @@ import numpy
 import scipy
 import scipy.sparse
 cimport numpy
+numpy.import_array()
+
 import msmtools.estimation
 import warnings
 import msmtools.util.exceptions
 
 cdef extern from "_mle_trev.h":
-  int _mle_trev_sparse(double * const T_data, const double * const CCt_data, const int * const i_indices, const int * const j_indices, const int len_CCt, const double * const sum_C, const int dim, const double maxerr, const int maxiter)
+  int _mle_trev_sparse(double * const T_data, const double * const CCt_data, 
+                       const int * const i_indices, const int * const j_indices,
+                       const int len_CCt, const double * const sum_C, const int dim,
+                       const double maxerr, const int maxiter,
+                       #double * const mu,
+                       double eps_mu)
 
-def mle_trev(C, double maxerr = 1.0E-12, int maxiter = 1000000, warn_not_converged = True):
+
+def mle_trev(C, double maxerr=1.0E-12, int maxiter=int(1.0E6),
+             warn_not_converged=True, return_statdist=False,
+             eps_mu=1.0E-15):
 
   assert maxerr > 0, 'maxerr must be positive'
   assert maxiter > 0, 'maxiter must be positive'
@@ -35,7 +45,7 @@ def mle_trev(C, double maxerr = 1.0E-12, int maxiter = 1000000, warn_not_converg
 
   # prepare data array of T in coo format
   cdef numpy.ndarray[double, ndim=1, mode="c"] T_data = numpy.zeros(n_data, dtype=numpy.float64, order='C')
-
+  #cdef numpy.ndarray[double, ndim=1, mode="c"] mu = numpy.zeros(C.shape[0], dtype=numpy.float64, order='C')
   err = _mle_trev_sparse(
         <double*> numpy.PyArray_DATA(T_data),
         <double*> numpy.PyArray_DATA(CCt_data),
@@ -45,7 +55,10 @@ def mle_trev(C, double maxerr = 1.0E-12, int maxiter = 1000000, warn_not_converg
         <double*> numpy.PyArray_DATA(C_sum),
         CCt.shape[0],
         maxerr,
-        maxiter)
+        maxiter,
+        #<double*> numpy.PyArray_DATA(mu),
+        eps_mu)
+
 
   if err == -1:
     raise Exception('Out of memory.')
@@ -54,7 +67,14 @@ def mle_trev(C, double maxerr = 1.0E-12, int maxiter = 1000000, warn_not_converg
   elif err == -3:
     raise Exception('Some row and corresponding column of C have zero counts.')
   elif err == -5 and warn_not_converged:
-    warnings.warn('Reversible transition matrix estimation didn\'t converge.', msmtools.util.exceptions.NotConvergedWarning)
-
+    warnings.warn('Reversible transition matrix estimation didn\'t converge.',
+                  msmtools.util.exceptions.NotConvergedWarning)
+  elif err == -6:
+    raise Exception("Stationary distribution contains entries smaller than %s during"
+                    " iteration" % eps_mu)
   # T matrix has the same shape and positions of nonzero elements as CCt
-  return scipy.sparse.csr_matrix((T_data,(i_indices,j_indices)),shape=CCt.shape)
+  T = scipy.sparse.csr_matrix((T_data, (i_indices, j_indices)), shape=CCt.shape)
+  if return_statdist:
+      return T#, mu
+  else:
+      return T

--- a/msmtools/estimation/tests/test_mle_trev.py
+++ b/msmtools/estimation/tests/test_mle_trev.py
@@ -87,6 +87,18 @@ class Test_mle_trev(unittest.TestCase):
         assert_allclose(T_dense_reference, T_dense_scaled_1)
         assert_allclose(T_dense_reference, T_dense_scaled_2)
 
+    @unittest.skip("not yet fully implemented")
+    def test_return_statdist(self):
+        C = np.loadtxt(testpath + 'C_1_lag.dat')
+        # dense
+        T, mu = apicall(C, reversible=True, method='dense', return_statdist=True)
+        mu_manual = msmtools.analysis.stationary_distribution(T)
+        np.testing.assert_allclose(mu, mu_manual)
+        # sparse
+        T, mu = apicall(C, reversible=True, method='sparse', return_statdist=True)
+        mu_manual = msmtools.analysis.stationary_distribution(T)
+        np.testing.assert_allclose(mu, mu_manual)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This also partially introduces handling for optional "return_statdist" keyword.

An exception is being raised if some element of stationary distribution vanishes below the given threshold. 
