### PR TITLE
Fixed normalization in reversible transition matrix estimation 

### DIFF
--- a/msmtools/estimation/dense/_mle_trev.c
+++ b/msmtools/estimation/dense/_mle_trev.c
@@ -93,7 +93,7 @@ int _mle_trev_dense(double * const T, const double * const CCt,
 
 	x_norm = 0;
     for(i=0; i<dim; i++) { 
-      sum_x_new[i]=0;
+      sum_x_new[i] = 0;
 	  for(j=0; j<dim; j++) {
          sum_x_new[i] += CCt(i,j) / (sum_C[i]/sum_x[i] + sum_C[j]/sum_x[j]);
 	  }
@@ -111,12 +111,17 @@ int _mle_trev_dense(double * const T, const double * const CCt,
     rel_err = relative_error(dim, sum_x, sum_x_new);
   } while(rel_err > maxerr && iteration < maxiter && !interrupted);
 
-  /* calculate T */
-  for(i=0; i<dim; i++) { 
+  /* calculate T*/
+  for(i=0; i<dim; i++) {
+    sum_x[i] = 0;  // updated sum
     for(j=0; j<dim; j++) {
-      value = CCt(i,j) / (sum_C[i]/sum_x_new[i] + sum_C[j]/sum_x_new[j]);
-      T(i,j) = value / sum_x_new[i];
+      T(i,j) = CCt(i,j) / (sum_C[i]/sum_x_new[i] + sum_C[j]/sum_x_new[j]);  // X_ij
+      sum_x[i] += T(i,j);  // update sum with X_ij
 	}
+	/* normalize X to T*/
+    for(j=0; j<dim; j++) {
+      T(i,j) /= sum_x[i];
+    }
   }
 
   if(iteration==maxiter) { err=5; goto error; } 

--- a/msmtools/estimation/sparse/_mle_trev.c
+++ b/msmtools/estimation/sparse/_mle_trev.c
@@ -117,13 +117,19 @@ int _mle_trev_sparse(double * const T_data, const double * const CCt_data,
     rel_err = relative_error(dim, sum_x, sum_x_new);
   } while(rel_err > maxerr && iteration < maxiter && !interrupted);
 
-  /* calculate T */
+  /* calculate X */
+  for(i=0; i<dim; i++) sum_x[i] = 0;  // updated sum
   for(t=0; t<len_CCt; t++) {
     i = i_indices[t];
     j = j_indices[t];
     CCt_ij = CCt_data[t];
-    value = CCt_ij / (sum_C[i]/sum_x_new[i] + sum_C[j]/sum_x_new[j]);
-    T_data[t] = value / sum_x_new[i];
+    T_data[t] = CCt_ij / (sum_C[i]/sum_x_new[i] + sum_C[j]/sum_x_new[j]);
+    sum_x[i] += T_data[t];  // update sum with X_ij
+  }
+  /* normalize to T */
+  for(t=0; t<len_CCt; t++) {
+    i = i_indices[t];
+    T_data[t] /= sum_x[i];
   }
 
   if(iteration==maxiter) { err=5; goto error; }


### PR DESCRIPTION
This is an important emergency fix. 

Previous impl led to significant numerical errors in some cases. It's easy to come up with count matrices and convergence parameters where the previous implementation did not yield properly normalized transition matrices (e.g. errors in the row sum on the order of 10^-6), that would fail the is_transition_matrix() test and therefore raise exceptions in PyEMMA.

Please always run PyEMMA tests when changing things at msmtools.
