### PR TITLE
Improved count matrix performance

### DIFF
--- a/msmtools/estimation/api.py
+++ b/msmtools/estimation/api.py
@@ -74,7 +74,7 @@ __all__ = ['bootstrap_trajectories',
            'tmatrix_cov',
            'tmatrix_sampler']
 
-# append shortcuts separately in order to avoid code syntax error
+# append shortcuts separately in order to avoid complaints by syntax checker
 __all__.append('histogram')
 __all__.append('nstates')
 __all__.append('cmatrix')
@@ -123,7 +123,6 @@ def number_of_states(dtrajs, only_used=False):
 # Count matrix
 ################################################################################
 
-# DONE: Benjamin
 @shortcut('cmatrix')
 def count_matrix(dtraj, lag, sliding=True, sparse_return=True, nstates=None):
     r"""Generate a count matrix from given microstate trajectory.
@@ -160,7 +159,8 @@ def count_matrix(dtraj, lag, sliding=True, sparse_return=True, nstates=None):
 
     Transition counts :math:`c_{ij}(\tau)` are generated according to
 
-    .. math:: c_{ij}(\tau)=\sum_{k=0}^{\left \lfloor \frac{N}{\tau} \right \rfloor -2}\chi_{i}(X_{k\tau})\chi_{j}(X_{(k+1)\tau}).
+    .. math:: c_{ij}(\tau) = \sum_{k=0}^{\left \lfloor \frac{N}{\tau} \right \rfloor -2}
+                                        \chi_{i}(X_{k\tau})\chi_{j}(X_{(k+1)\tau}).
 
     :math:`\chi_{i}(x)` is the indicator function of :math:`i`, i.e
     :math:`\chi_{i}(x)=1` for :math:`x=i` and :math:`\chi_{i}(x)=0` for
@@ -195,7 +195,7 @@ def count_matrix(dtraj, lag, sliding=True, sparse_return=True, nstates=None):
 
     >>> C_sliding = count_matrix(dtraj, tau)
 
-    The generated matrix is a sparse matrix in COO-format. For
+    The generated matrix is a sparse matrix in CSR-format. For
     convenient printing we convert it to a dense ndarray.
 
     >>> C_sliding.toarray()
@@ -214,7 +214,8 @@ def count_matrix(dtraj, lag, sliding=True, sparse_return=True, nstates=None):
     # convert dtraj input, if it contains out of nested python lists to
     # a list of int ndarrays.
     dtraj = _ensure_dtraj_list(dtraj)
-    return sparse.count_matrix.count_matrix_mult(dtraj, lag, sliding=sliding, sparse=sparse_return, nstates=nstates)
+    return sparse.count_matrix.count_matrix_coo2_mult(dtraj, lag, sliding=sliding,
+                                                      sparse=sparse_return, nstates=nstates)
 
 
 @shortcut('effective_cmatrix')
@@ -272,18 +273,6 @@ def effective_count_matrix(dtrajs, lag, average='row', mact=1.0):
 
     dtrajs = _ensure_dtraj_list(dtrajs)
     return sparse.effective_counts.effective_count_matrix(dtrajs, lag, average=average, mact=mact)
-
-
-# # TODO: Implement in Python directly
-# def count_matrix_cores(dtraj, cores, lag, sliding=True):
-# r"""Generate a countmatrix for the milestoning process on the
-#     given core sets.
-#
-#     """
-#     raise NotImplementedError('Not implemented.')
-#
-# # shortcut
-# cmatrix_cores=count_matrix_cores
 
 
 ################################################################################
@@ -400,7 +389,6 @@ def bootstrap_counts(dtrajs, lagtime, corrlength=None):
 # Connectivity
 ################################################################################
 
-# DONE: Ben Implement in Python directly
 def connected_sets(C, directed=True):
     r"""Compute connected sets of microstates.
 
@@ -457,7 +445,6 @@ def connected_sets(C, directed=True):
         return sparse.connectivity.connected_sets(C, directed=directed)
 
 
-# DONE: Ben
 def largest_connected_set(C, directed=True):
     r"""Largest connected component for a directed graph with edge-weights
     given by the count matrix.
@@ -513,7 +500,6 @@ def largest_connected_set(C, directed=True):
         return sparse.connectivity.largest_connected_set(C, directed=directed)
 
 
-# DONE: Ben
 @shortcut('connected_cmatrix')
 def largest_connected_submatrix(C, directed=True, lcc=None):
     r"""Compute the count matrix on the largest connected set.
@@ -576,7 +562,6 @@ def largest_connected_submatrix(C, directed=True, lcc=None):
         return sparse.connectivity.largest_connected_submatrix(C, directed=directed, lcc=lcc)
 
 
-# DONE: Jan
 def is_connected(C, directed=True):
     """Check connectivity of the given matrix.
 
@@ -632,7 +617,6 @@ def is_connected(C, directed=True):
 # priors
 ################################################################################
 
-# DONE: Frank, Ben
 def prior_neighbor(C, alpha=0.001):
     r"""Neighbor prior for the given count matrix.
 
@@ -679,7 +663,6 @@ def prior_neighbor(C, alpha=0.001):
         return sparse.prior.prior_neighbor(C, alpha=alpha)
 
 
-# DONE: Frank, Ben
 def prior_const(C, alpha=0.001):
     r"""Constant prior for given count matrix.
 
@@ -724,7 +707,7 @@ def prior_const(C, alpha=0.001):
 
 __all__.append('prior_const')
 
-# DONE: Ben
+
 def prior_rev(C, alpha=-1.0):
     r"""Prior counts for sampling of reversible transition
     matrices.
@@ -781,9 +764,7 @@ def prior_rev(C, alpha=-1.0):
         return sparse.prior.prior_rev(C, alpha=alpha)
 
 
-    ################################################################################
-
-
+################################################################################
 # Transition matrix
 ################################################################################
 
@@ -927,7 +908,7 @@ def transition_matrix(C, reversible=False, mu=None, method='auto', **kwargs):
             sparse_computation = True
     else:
         raise ValueError(('method="%s" is no valid choice. It should be one of'
-                          '"dense", "sparse" or "auto".')%method)
+                          '"dense", "sparse" or "auto".') % method)
 
     # convert input type
     if sparse_computation and not sparse_input_type:
@@ -978,7 +959,6 @@ def transition_matrix(C, reversible=False, mu=None, method='auto', **kwargs):
         return T
 
 
-# DONE: FN+Jan+Ben Implement in Python directly
 def log_likelihood(C, T):
     r"""Log-likelihood of the count matrix given a transition matrix.
 
@@ -1042,9 +1022,9 @@ def log_likelihood(C, T):
         # use the dense likelihood calculator for all other cases
         # if a mix of dense/sparse C/T matrices is used, then both
         # will be converted to ndarrays.
-        if (not isinstance(C, np.ndarray)):
+        if not isinstance(C, np.ndarray):
             C = np.array(C)
-        if (not isinstance(T, np.ndarray)):
+        if not isinstance(T, np.ndarray):
             T = np.array(T)
         # computation is still efficient, because we only use terms
         # for nonzero elements of T
@@ -1052,7 +1032,6 @@ def log_likelihood(C, T):
         return np.dot(C[nz], np.log(T[nz]))
 
 
-# DONE: Ben
 def tmatrix_cov(C, k=None):
     r"""Covariance tensor for non-reversible transition matrix posterior.
 
@@ -1091,7 +1070,6 @@ def tmatrix_cov(C, k=None):
     return dense.covariance.tmatrix_cov(C, row=k)
 
 
-# DONE: Ben
 def error_perturbation(C, S):
     r"""Error perturbation for given sensitivity matrix.
 
@@ -1135,10 +1113,10 @@ def error_perturbation(C, S):
 
     The sensitivity is the covariance matrix for the observable
 
-    .. math:: \text{cov}[f_{\alpha}(T),f_{\beta}(T)]=\sum_{i,j,k,l} s_{\alpha i j} \text{cov}[t_{ij}, t_{kl}] s_{\beta kl}
+    .. math:: \text{cov}[f_{\alpha}(T),f_{\beta}(T)] = \sum_{i,j,k,l} s_{\alpha i j}
+                                                       \text{cov}[t_{ij}, t_{kl}] s_{\beta kl}
 
     """
-
     if issparse(C):
         warnings.warn("Error-perturbation will be dense for sparse input")
         C = C.toarray()
@@ -1148,6 +1126,7 @@ def error_perturbation(C, S):
 def _showSparseConversionWarning():
     warnings.warn('Converting input to dense, since method is '
                   'currently only implemented for dense matrices.', UserWarning)
+
 
 def sample_tmatrix(C, nsample=1, nsteps=None, reversible=False, mu=None, T0=None, return_statdist=False):
     r"""samples transition matrices from the posterior distribution
@@ -1202,6 +1181,7 @@ def sample_tmatrix(C, nsample=1, nsteps=None, reversible=False, mu=None, T0=None
 
     sampler = tmatrix_sampler(C, reversible=reversible, mu=mu, T0=T0, nsteps=nsteps)
     return sampler.sample(nsamples=nsample, return_statdist=return_statdist)
+
 
 def tmatrix_sampler(C, reversible=False, mu=None, T0=None, nsteps=None, prior='sparse'):
     r"""Generate transition matrix sampler object.

--- a/msmtools/estimation/sparse/count_matrix.py
+++ b/msmtools/estimation/sparse/count_matrix.py
@@ -451,3 +451,65 @@ def count_matrix_bincount_mult(dtrajs, lag, sliding=True, sparse=True, nstates=N
         return scipy.sparse.csr_matrix(C)
     else:
         return C
+
+
+################################################################################
+# improved COO-based method
+################################################################################
+
+def count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True, nstates=None):
+    r"""Generate a count matrix from a given list discrete trajectories.
+
+    The generated count matrix is a sparse matrix in compressed
+    sparse row (CSR) or numpy ndarray format.
+
+    Parameters
+    ----------
+    dtraj : list of ndarrays
+        discrete trajectories
+    lag : int
+        Lagtime in trajectory steps
+    sliding : bool, optional
+        If true the sliding window approach
+        is used for transition counting
+    sparse : bool (optional)
+        Whether to return a dense or a sparse matrix
+    nstates : int, optional
+        Enforce a count-matrix with shape=(nstates, nstates). If there are
+        more states in the data, this will lead to an exception.
+
+    Returns
+    -------
+    C : scipy.sparse.csr_matrix or numpy.ndarray
+        The countmatrix at given lag in scipy compressed sparse row
+        or numpy ndarray format.
+
+    """
+    # Determine number of states
+    if nstates is None:
+        from msmtools.dtraj import number_of_states
+        nstates = number_of_states(dtrajs)
+    rows = []
+    cols = []
+    # collect transition index pairs
+    for dtraj in dtrajs:
+        if dtraj.size > lag:
+            if (sliding):
+                rows.append(dtraj[0:-lag])
+                cols.append(dtraj[lag:])
+            else:
+                rows.append(dtraj[0:-lag:lag])
+                cols.append(dtraj[lag::lag])
+    # is there anything?
+    if len(rows) == 0:
+        raise ValueError('No counts found - lag ' + str(lag) + ' may exceed all trajectory lengths.')
+    # feed into one COO matrix
+    row = np.concatenate(rows)
+    col = np.concatenate(cols)
+    data = np.ones(row.size)
+    C = scipy.sparse.coo_matrix((data, (row, col)), shape=(nstates, nstates))
+    # export to output format
+    if sparse:
+        return C.tocsr()
+    else:
+        return C.toarray()


### PR DESCRIPTION
This PR mainly removes inefficiencies of transition matrix counting encountered in cases of many states or many trajectories. Additionally, some PEP coding violations were fixed and deprecated comments and TODO statements were removed.

In some cases (significant more than 1000 states or more than 10000 trajectories), transition matrix counting could have been _really slow_.  `msmtools.estimation.count_matrix` is now using the new counting method `msmtools.estimation.sparse.count_matrix.count_matrix_coo2_mult`. To effect on performance is illustrated by following test code:

``` python
from msmtools.estimation.sparse.count_matrix import count_matrix_bincount_mult
from msmtools.estimation.sparse.count_matrix import count_matrix_coo_mult
from msmtools.estimation.sparse.count_matrix import count_matrix_coo2_mult

def count_performance(dtrajs, lag=1):
    import time
    nstates = msmtools.estimation.number_of_states(dtrajs)
    t1 = time.time()
    count_matrix_bincount_mult(dtrajs, lag)
    t2 = time.time()
    count_matrix_coo_mult(dtrajs, lag)
    t3 = time.time()
    count_matrix_coo2_mult(dtrajs, lag)
    t4 = time.time()
    print len(dtrajs), '\t', dtrajs[0].size, '\t', nstates, '\t', int(1000*(t2-t1)), '\t', int(1000*(t3-t2)), '\t', int(1000*(t4-t3))

print '[1]: count_matrix_bincount_mult'
print '[2]: count_matrix_coo_mult'
print '[3]: count_matrix_coo2_mult'
print
print 'ntraj\tlength\tnstates\t[1]\t[2]\t[3]'
print '----------------------------------------------'
# long trajectory
count_performance([np.random.choice(10, size=10000)])
count_performance([np.random.choice(10, size=100000)])
count_performance([np.random.choice(10, size=900000)])
count_performance([np.random.choice(100, size=10000)])
count_performance([np.random.choice(100, size=100000)])
count_performance([np.random.choice(100, size=900000)])
count_performance([np.random.choice(1000, size=10000)])
count_performance([np.random.choice(1000, size=100000)])
count_performance([np.random.choice(1000, size=900000)])
count_performance([np.random.choice(10000, size=10000)])
count_performance([np.random.choice(10000, size=100000)])
count_performance([np.random.choice(10000, size=900000)])
# many short trajectories
count_performance([np.random.choice(10, size=2) for i in range(10000)])
count_performance([np.random.choice(100, size=2) for i in range(10000)])
count_performance([np.random.choice(1000, size=2) for i in range(10000)])
# many short trajectories II
count_performance([np.random.choice(10, size=20) for i in range(10000)])
count_performance([np.random.choice(100, size=20) for i in range(10000)])
count_performance([np.random.choice(1000, size=20) for i in range(10000)])
```

Results (time in milliseconds) on my machine (MacOS 10.10.1, Intel i7@1.7 GHz, 8 GB Ram):

```
[1]: count_matrix_bincount_mult
[2]: count_matrix_coo_mult
[3]: count_matrix_coo2_mult

ntraj   length  nstates [1]     [2]     [3]
----------------------------------------------
1       10000   10      0       1       1
1       100000  10      2       11      9
1       900000  10      18      86      85
1       10000   100     0       1       0
1       100000  100     2       14      13
1       900000  100     16      85      89
1       10000   1000    32      1       1
1       100000  1000    36      11      10
1       900000  1000    116     131     136
1       10000   9997    3444    5       2
1       100000  10000   2926    6       8
1       900000  10000   3061    102     96
10000   2       10      139     3772    84
10000   2       100     403     4167    67
10000   2       1000    63678   4350    83
10000   20      10      148     4029    105
10000   20      100     443     4892    83
10000   20      1000    50849   10013   109
```

It is seen that while the new method does not always win, it never leads to an explosion of the runtime while the two previous methods could become really useless with big data. If there are no objections, I will remove the old counting methods in a subsequent PR.
