### PR TITLE
[tmatrix-sampler] added n_jobs parameter to sampler.update method.

### DIFF
--- a/msmtools/estimation/tests/test_tmatrix_sampling.py
+++ b/msmtools/estimation/tests/test_tmatrix_sampling.py
@@ -135,6 +135,32 @@ class TestAnalyticalDistribution(unittest.TestCase):
         P_analytical = self.probabilities_revpi(self.xedges)
         self.assertTrue(np.all( np.abs(P_sampled - P_analytical) < 0.01 ))
 
+    def test_parallel_rev(self):
+        N = self.N
+        sampler = tmatrix_sampler(self.C, reversible=True)
+        M = self.C.shape[0]
+        T_sample = sampler.sample(nsamples=N, n_jobs=2)
+        p_12 = T_sample[:, 0, 1]
+        p_21 = T_sample[:, 1, 0]
+        H, xed, yed = np.histogram2d(p_12, p_21, bins=(self.xedges, self.yedges))
+        P_sampled = H / self.N
+        P_analytical = self.probabilities_rev(self.xedges, self.yedges)
+
+        self.assertTrue(np.all(np.abs(P_sampled - P_analytical) < 0.01))
+
+    def test_parallel_rev_statdist(self):
+        N = self.N
+        sampler = tmatrix_sampler(self.C, reversible=True)
+        M = self.C.shape[0]
+        T_sample, pi_sample = sampler.sample(nsamples=N, return_statdist=True, n_jobs=2)
+        p_12 = T_sample[:, 0, 1]
+        p_21 = T_sample[:, 1, 0]
+        H, xed, yed = np.histogram2d(p_12, p_21, bins=(self.xedges, self.yedges))
+        P_sampled = H / self.N
+        P_analytical = self.probabilities_rev(self.xedges, self.yedges)
+
+        self.assertTrue(np.all(np.abs(P_sampled - P_analytical) < 0.01))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ metadata = dict(
                       'scipy>=0.11',
                       'six',
                       'decorator',
+                      'joblib',
                       ],
     zip_safe=False,
 )

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - six
     - decorator
     - nomkl
+    - joblib
 
   run:
     - python
@@ -28,6 +29,7 @@ requirements:
     - six
     - decorator
     - nomkl
+    - joblib
 
 test:
   requires:


### PR DESCRIPTION
Uses joblib to utilize all cpus during sampling.

timing results:
In [27]:  %timeit _= sampler.sample(nsamples=10000, n_jobs=1)
1 loop, best of 3: 15.6 s per loop

In [25]:  %timeit _= sampler.sample(nsamples=10000, n_jobs=2)
1 loop, best of 3: 9.27 s per loop

In [26]:  %timeit _= sampler.sample(nsamples=10000, n_jobs=3)
1 loop, best of 3: 8.48 s per loop

Note that 3 jobs does not scale on my old (6 years by now) work laptop, since it only has 2 physical cores.
