### PR TITLE
Added fast reversible transition matrix estimation 

### DIFF
--- a/msmtools/analysis/dense/decomposition_test.py
+++ b/msmtools/analysis/dense/decomposition_test.py
@@ -51,8 +51,8 @@ class TestDecomposition(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 

--- a/msmtools/analysis/dense/stationary_vector_test.py
+++ b/msmtools/analysis/dense/stationary_vector_test.py
@@ -40,8 +40,8 @@ class TestStationaryVector(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 

--- a/msmtools/analysis/sparse/decomposition_test.py
+++ b/msmtools/analysis/sparse/decomposition_test.py
@@ -49,8 +49,8 @@ class TestDecomposition(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 

--- a/msmtools/analysis/sparse/stationary_vector_test.py
+++ b/msmtools/analysis/sparse/stationary_vector_test.py
@@ -48,8 +48,8 @@ class TestStationaryVector(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 

--- a/msmtools/analysis/tests/test_decomposition.py
+++ b/msmtools/analysis/tests/test_decomposition.py
@@ -55,8 +55,8 @@ class TestDecompositionDense(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 
@@ -388,8 +388,8 @@ class TestDecompositionSparse(unittest.TestCase):
         q = np.zeros(self.dim)
         q[1:] = 0.5
 
-        p[self.dim / 2 - 1] = 0.001
-        q[self.dim / 2 + 1] = 0.001
+        p[int(self.dim / 2 - 1)] = 0.001
+        q[int(self.dim / 2 + 1)] = 0.001
 
         self.bdc = BirthDeathChain(q, p)
 

--- a/msmtools/estimation/dense/transition_matrix.py
+++ b/msmtools/estimation/dense/transition_matrix.py
@@ -49,3 +49,39 @@ def transition_matrix_non_reversible(C):
         raise ValueError(
             "Transition matrix has row sum of " + str(np.min(rowsums)) + ". Must have strictly positive row sums.")
     return np.divide(C, rowsums[:, np.newaxis])
+
+def transition_matrix_reversible_pisym(C):
+    r"""
+    Estimates reversible transition matrix as follows:
+
+    ..:math:
+        p_{ij} = c_{ij} / c_i where c_i = sum_j c_{ij}
+        \pi_j = \sum_j \pi_i p_{ij}
+        x_{ij} = \pi_i p_{ij} + \pi_j p_{ji}
+        p^{rev}_{ij} = x_{ij} / x_i where x_i = sum_j x_{ij}
+
+    In words: takes the nonreversible transition matrix estimate, uses its
+    stationary distribution to compute an equilibrium correlation matrix,
+    symmetrizes that correlation matrix and then normalizes to the reversible
+    transition matrix estimate.
+
+    Parameters
+    ----------
+    C: ndarray, shape (n,n)
+        count matrix
+
+    Returns
+    -------
+    T: Estimated transition matrix
+
+    """
+    # nonreversible estimate
+    T_nonrev = transition_matrix_non_reversible(C)
+    from msmtools.analysis import stationary_distribution
+    pi = stationary_distribution(T_nonrev)
+    # correlation matrix
+    X = pi[:, None] * T_nonrev
+    X = X.T + X
+    # result
+    T_rev = X / X.sum(axis=1)[:, None]
+    return T_rev

--- a/msmtools/estimation/sparse/transition_matrix.py
+++ b/msmtools/estimation/sparse/transition_matrix.py
@@ -60,3 +60,40 @@ def correct_transition_matrix(T, reversible=None):
     if max_sum == 0.0:
          max_sum = 1.0
     return (T + scipy.sparse.diags(-row_sums+max_sum, 0)) / max_sum
+
+def transition_matrix_reversible_pisym(C):
+    r"""
+    Estimates reversible transition matrix as follows:
+
+    ..:math:
+        p_{ij} = c_{ij} / c_i where c_i = sum_j c_{ij}
+        \pi_j = \sum_j \pi_i p_{ij}
+        x_{ij} = \pi_i p_{ij} + \pi_j p_{ji}
+        p^{rev}_{ij} = x_{ij} / x_i where x_i = sum_j x_{ij}
+
+    In words: takes the nonreversible transition matrix estimate, uses its
+    stationary distribution to compute an equilibrium correlation matrix,
+    symmetrizes that correlation matrix and then normalizes to the reversible
+    transition matrix estimate.
+
+    Parameters
+    ----------
+    C: ndarray, shape (n,n)
+        count matrix
+
+    Returns
+    -------
+    T: Estimated transition matrix
+
+    """
+    # nonreversible estimate
+    T_nonrev = transition_matrix_non_reversible(C)
+    from msmtools.analysis import stationary_distribution
+    pi = stationary_distribution(T_nonrev)
+    # correlation matrix
+    X = scipy.sparse.diags(pi).dot(T_nonrev)
+    X = X.T + X
+    # result
+    pi_rev = X.sum(axis=1)
+    T_rev = scipy.sparse.diags(1.0/pi_rev).dot(X)
+    return T_rev


### PR DESCRIPTION
Using pi symmetrization:
        p_{ij} = c_{ij} / c_i where c_i = sum_j c_{ij}
        \pi_j = \sum_j \pi_i p_{ij}
        x_{ij} = \pi_i p_{ij} + \pi_j p_{ji}
        p^{rev}_{ij} = x_{ij} / x_i where x_i = sum_j x_{ij}

In words: takes the nonreversible transition matrix estimate, uses its
stationary distribution to compute an equilibrium correlation matrix,
symmetrizes that correlation matrix and then normalizes to the reversible
transition matrix estimate.