### PR TITLE
[tpt.pathways] Handle case of non-positive flux matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - PATH=$HOME/miniconda/bin:$PATH
   matrix:
-    - python=2.7  CONDA_PY=27  CONDA_NPY=17
+    - python=2.7  CONDA_PY=27  CONDA_NPY=18
     - python=3.5  CONDA_PY=35  CONDA_NPY=110
     - python=3.5  CONDA_PY=35  CONDA_NPY=111
     - python=3.6  CONDA_PY=36  CONDA_NPY=112

--- a/msmtools/flux/sparse/pathways.py
+++ b/msmtools/flux/sparse/pathways.py
@@ -29,10 +29,12 @@ import scipy.sparse.csgraph as csgraph
 from scipy.sparse import coo_matrix
 from six.moves import range
 
+
 class PathwayError(Exception):
     """Exception for failed attempt to find pathway in a given flux
     network"""
     pass
+
 
 def find_bottleneck(F, A, B):
     r"""Find dynamic bottleneck of flux network.
@@ -52,6 +54,8 @@ def find_bottleneck(F, A, B):
     The edge corresponding to the dynamic bottleneck
 
     """
+    if F.nnz == 0:
+        raise PathwayError('no more pathways left: Flux matrix does not contain any positive entries')
     F = F.tocoo()
     n = F.shape[0]
 
@@ -162,6 +166,8 @@ def pathway(F, A, B):
         The dominant reaction-pathway
 
     """
+    if F.nnz == 0:
+        raise PathwayError('no more pathways left: Flux matrix does not contain any positive entries')
     b1, b2, F = find_bottleneck(F, A, B)
     if np.any(A == b1):
         wL = [b1, ]
@@ -175,8 +181,8 @@ def pathway(F, A, B):
         wR = [b2, ]
     elif np.any(A == b2):
         raise PathwayError(("Roles of vertices b1 and b2 are switched."
-                          "This should never happen for a correct flux network"
-                          "obtained from a reversible transition meatrix."))
+                            "This should never happen for a correct flux network"
+                            "obtained from a reversible transition meatrix."))
     else:
         wR = pathway(F, [b2, ], B)
     return wL + wR
@@ -234,6 +240,7 @@ def remove_path(F, path):
         F[i, j] -= c
     return F
 
+
 def pathways(F, A, B, fraction=1.0, maxiter=1000, tol=1e-14):
     r"""Decompose flux network into dominant reaction paths.
 
@@ -252,7 +259,7 @@ def pathways(F, A, B, fraction=1.0, maxiter=1000, tol=1e-14):
     tol : float, optional
         Floating point tolerance. The iteration is terminated once the
         relative capacity of all discovered path matches the desired
-        fraction within floating point tolerance        
+        fraction within floating point tolerance
 
     Returns
     -------


### PR DESCRIPTION
For certain inputs it could happen that the pathway decomposition
kicks out all of the entries of the flux matrix F, before reaching the
total flux convergence criterion. Now the input is checked for this case.

This happend eg. for Fs generated from P, pi estimated with
msmtools.estimation.tmatrix(reversible=True, return_statdist=True).
The matrix, stat vector pair in the attached test shows such an example.

Although it is not fully clear to me, why this happens, checking the
input, leads to correct termination and the result looks good.

Fixes #106