### PR TITLE
Parallelize effective count matrix

### DIFF
--- a/msmtools/estimation/api.py
+++ b/msmtools/estimation/api.py
@@ -220,7 +220,7 @@ def count_matrix(dtraj, lag, sliding=True, sparse_return=True, nstates=None):
 
 
 @shortcut('effective_cmatrix')
-def effective_count_matrix(dtrajs, lag, average='row', mact=1.0):
+def effective_count_matrix(dtrajs, lag, average='row', mact=1.0, n_jobs=1, callback=None):
     """ Computes the statistically effective transition count matrix
 
     Given a list of discrete trajectories, compute the effective number of statistically uncorrelated transition
@@ -260,6 +260,10 @@ def effective_count_matrix(dtrajs, lag, average='row', mact=1.0):
         This is a purely heuristic factor trying to compensate this effect.
         This parameter might be removed in the future when a more robust
         estimation method of the autocorrelation time is used.
+    n_jobs: int, default=1
+        If greater one, the function will be evaluated with multiple processes.
+    callback: callable, default=None
+        will be called for every statistical inefficency computed (number of nonzero elements in count matrix).
 
     See also
     --------
@@ -273,7 +277,7 @@ def effective_count_matrix(dtrajs, lag, average='row', mact=1.0):
     """
 
     dtrajs = _ensure_dtraj_list(dtrajs)
-    return sparse.effective_counts.effective_count_matrix(dtrajs, lag, average=average, mact=mact)
+    return sparse.effective_counts.effective_count_matrix(dtrajs, lag, average=average, mact=mact, n_jobs=n_jobs, callback=callback)
 
 
 ################################################################################

--- a/msmtools/estimation/api.py
+++ b/msmtools/estimation/api.py
@@ -277,6 +277,10 @@ def effective_count_matrix(dtrajs, lag, average='row', mact=1.0, n_jobs=1, callb
     """
 
     dtrajs = _ensure_dtraj_list(dtrajs)
+    import os
+    # enforce one job on windows.
+    if os.name == 'nt':
+        n_jobs = 1
     return sparse.effective_counts.effective_count_matrix(dtrajs, lag, average=average, mact=mact, n_jobs=n_jobs, callback=callback)
 
 

--- a/msmtools/estimation/sparse/effective_counts.py
+++ b/msmtools/estimation/sparse/effective_counts.py
@@ -155,12 +155,13 @@ def statistical_inefficiencies(dtrajs, lag, C=None, truncate_acf=True, mact=2.0,
     # count matrix
     if C is None:
         C = count_matrix_coo2_mult(dtrajs, lag, sliding=True, sparse=True)
-    if callback is not None and not callable(callback):
-        raise ValueError('Provided callback is not callable')
-    else:
-        # multiprocess callback interface takes one argument. Wrap it to avoid requesting a given signature.
-        old_callback = callback
-        callback = lambda x: old_callback()
+    if callback is not None:
+        if not callable(callback):
+            raise ValueError('Provided callback is not callable')
+        else:
+            # multiprocess callback interface takes one argument. Wrap it to avoid requesting a given signature.
+            old_callback = callback
+            callback = lambda x: old_callback()
     # split sequences
     splitseq = _split_sequences_multitraj(dtrajs, lag)
     # compute inefficiencies

--- a/msmtools/estimation/sparse/effective_counts.py
+++ b/msmtools/estimation/sparse/effective_counts.py
@@ -187,7 +187,7 @@ def statistical_inefficiencies(dtrajs, lag, C=None, truncate_acf=True, mact=2.0,
             data[index] = statistical_inefficiency(_indicator_multitraj(splitseq, i, j),
                                                    truncate_acf=truncate_acf, mact=mact)
             if callback is not None:
-                callback()
+                callback(0)
     res = csr_matrix((data, (I, J)), shape=C.shape)
     return res
 

--- a/msmtools/estimation/tests/test_effective_count_matrix.py
+++ b/msmtools/estimation/tests/test_effective_count_matrix.py
@@ -26,6 +26,13 @@ from msmtools.estimation import count_matrix, effective_count_matrix
 
 """Unit tests for the transition_matrix module"""
 
+have_multiprocess_lib = True
+try:
+    import multiprocess
+    del multiprocess
+except ImportError:
+    have_multiprocess_lib = False
+
 
 class TestEffectiveCountMatrix(unittest.TestCase):
 
@@ -64,6 +71,28 @@ class TestEffectiveCountMatrix(unittest.TestCase):
         assert np.array_equal(Ceff.shape, C.shape)
         assert np.array_equal(C.nonzero(), Ceff.nonzero())
         assert np.all(Ceff.toarray() <= C.toarray())
+
+    @unittest.skipIf(not have_multiprocess_lib, 'multiprocess lib missing')
+    def test_multitraj_njobs(self):
+        dtrajs = [[1, 0, 1, 0, 1, 1, 0, 0, 0, 1], [2], [0, 1, 0, 1]]
+        # lag 1
+        C = count_matrix(dtrajs, 1)
+        Ceff = effective_count_matrix(dtrajs, 1, n_jobs=1)
+        assert np.array_equal(Ceff.shape, C.shape)
+        assert np.array_equal(C.nonzero(), Ceff.nonzero())
+        assert np.all(Ceff.toarray() <= C.toarray())
+
+        Ceff2 = effective_count_matrix(dtrajs, 1, n_jobs=2)
+        assert np.array_equal(Ceff2.shape, C.shape)
+        assert np.array_equal(C.nonzero(), Ceff2.nonzero())
+        assert np.all(Ceff2.toarray() <= C.toarray())
+
+        # lag 2
+        C = count_matrix(dtrajs, 2)
+        Ceff2 = effective_count_matrix(dtrajs, 2)
+        assert np.array_equal(Ceff2.shape, C.shape)
+        assert np.array_equal(C.nonzero(), Ceff2.nonzero())
+        assert np.all(Ceff2.toarray() <= C.toarray())
 
 
 class TestEffectiveCountMatrix_old_impl(unittest.TestCase):

--- a/msmtools/util/statistics.py
+++ b/msmtools/util/statistics.py
@@ -220,6 +220,7 @@ def statistical_inefficiency(X, truncate_acf=True, mact=1.0):
     X0 = [x-Xmean for x in X]
     # moments
     x2m = np.mean(xflat ** 2)
+    del xflat, Xmean
     # integrate damped autocorrelation
     corrsum = 0.0
     for lag in range(N):
@@ -228,7 +229,7 @@ def statistical_inefficiency(X, truncate_acf=True, mact=1.0):
         # cache partial sums
         for x in X0:
             Nx = len(x)  # length of this trajectory
-            if (Nx > lag):  # only use trajectories that are long enough
+            if Nx > lag:  # only use trajectories that are long enough
                 prod = x[:Nx-lag] * x[lag:]
                 acf += np.sum(prod)
                 n += Nx-lag

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
   requires:
     - pytest
     - pytest-cov
+    - multiprocess
 
 about:
   home: http://github.com/markovmodel/msmtools


### PR DESCRIPTION
Statistical inefficiencies are expensive to compute, so we do this in
parallel with n processes. We test that the result of the parallel evaluation
is the same as the sequential one.