### PR TITLE
[estimation/sampler_nonrev] fix dirichlet sampling for non-pos alphas

### DIFF
--- a/msmtools/estimation/dense/sampler_nrev.py
+++ b/msmtools/estimation/dense/sampler_nrev.py
@@ -31,7 +31,9 @@ from msmtools.analysis import stationary_distribution
 def update_nrev(alpha, P):
     N = alpha.shape[0]
     for i in range(N):
-        P[i, :] = np.random.dirichlet(alpha[i, :])   
+        # only pass positive alphas to dirichlet sampling.
+        positive = alpha[i, :] > 0
+        P[i, :][positive] = np.random.dirichlet(alpha[i, :][positive])
 
 
 class SamplerNonRev(object):
@@ -43,7 +45,7 @@ class SamplerNonRev(object):
         """Initial state from single sample"""
         self.P = np.zeros_like(Z)
         self.update()
-        
+
     def update(self, N=1):
         update_nrev(self.alpha, self.P)
 
@@ -54,5 +56,3 @@ class SamplerNonRev(object):
             return self.P, pi
         else:
             return self.P
-        
-    

--- a/msmtools/estimation/dense/sampler_nrev.py
+++ b/msmtools/estimation/dense/sampler_nrev.py
@@ -33,7 +33,7 @@ def update_nrev(alpha, P):
     for i in range(N):
         # only pass positive alphas to dirichlet sampling.
         positive = alpha[i, :] > 0
-        P[i, :][positive] = np.random.dirichlet(alpha[i, :][positive])
+        P[i, positive] = np.random.dirichlet(alpha[i, positive])
 
 
 class SamplerNonRev(object):

--- a/msmtools/estimation/tests/test_tmatrix_sampling.py
+++ b/msmtools/estimation/tests/test_tmatrix_sampling.py
@@ -40,27 +40,28 @@ from msmtools.analysis import is_transition_matrix
 
 class TestTransitionMatrixSampling(unittest.TestCase):
     def setUp(self):
-        self.C = np.array([[7,1],
+        self.C = np.array([[7,0],
                            [2,2]])
 
     def test_sample_nonrev_1(self):
-        P = sample_tmatrix(self.C)
+        P = sample_tmatrix(self.C, reversible=False)
         assert np.all(P.shape == self.C.shape)
         assert is_transition_matrix(P)
 
         # same with boject
-        sampler = tmatrix_sampler(self.C)
+        sampler = tmatrix_sampler(self.C, reversible=False)
         P = sampler.sample()
         assert np.all(P.shape == self.C.shape)
         assert is_transition_matrix(P)
 
     def test_sample_nonrev_10(self):
-        sampler = tmatrix_sampler(self.C)
+        sampler = tmatrix_sampler(self.C, reversible=False)
         Ps = sampler.sample(nsamples=10)
         assert len(Ps) == 10
         for i in range(10):
             assert np.all(Ps[i].shape == self.C.shape)
             assert is_transition_matrix(Ps[i])
+
 
 class TestAnalyticalDistribution(unittest.TestCase):
 


### PR DESCRIPTION
For states which have not been observed in the trajectory, or just once,
this sampling method failed for NumPy versions greater 1.13, because
the dirichlet function now checks for positive alphas.

In this fix we just omit these elements.