### PR TITLE
remove _compressed_sparsed_stack import

### DIFF
--- a/msmtools/estimation/sparse/mle/newton/objective_sparse.pyx
+++ b/msmtools/estimation/sparse/mle/newton/objective_sparse.pyx
@@ -24,7 +24,6 @@ r"""
 
 import numpy as np
 from scipy.sparse import csr_matrix, diags, bmat
-from scipy.sparse.construct import _compressed_sparse_stack
 from scipy.sparse.linalg import LinearOperator
 
 cimport cython


### PR DESCRIPTION
_compressed_sparse_stack is not available in scipy.sparce.constuct anymore as of scipy 1.8.0.
Further it appears to be unused.