### PR TITLE
Remove spconstruct

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,6 @@ mock_imports = [
     'scipy.sparse.csr',
     'scipy.sparse.csgraph',
     'scipy.sparse.sputils',
-    'scipy.sparse.construct',
     'scipy.sparse.linalg',
 ]
 

--- a/msmtools/analysis/sparse/assessment.py
+++ b/msmtools/analysis/sparse/assessment.py
@@ -22,7 +22,7 @@
 
 from scipy.sparse.csgraph import connected_components
 from scipy.sparse.sputils import isdense
-from scipy.sparse.construct import diags
+from scipy.sparse import diags
 
 from ...util.numeric import allclose_sparse
 

--- a/msmtools/analysis/sparse/expectations.py
+++ b/msmtools/analysis/sparse/expectations.py
@@ -26,7 +26,7 @@ expectation values for a given transition matrix.
 import numpy as np
 
 from scipy.sparse import coo_matrix
-from scipy.sparse.construct import diags
+from scipy.sparse import diags
 
 from .stationary_vector import stationary_distribution
 

--- a/msmtools/estimation/sparse/mle/newton/objective_sparse.pyx
+++ b/msmtools/estimation/sparse/mle/newton/objective_sparse.pyx
@@ -24,7 +24,6 @@ r"""
 
 import numpy as np
 from scipy.sparse import csr_matrix, diags, bmat
-from scipy.sparse.construct import _compressed_sparse_stack
 from scipy.sparse.linalg import LinearOperator
 
 cimport cython


### PR DESCRIPTION
As per the advise of scipy.sparse.constructs functions should be imported from
scipy.sparse instead.